### PR TITLE
Update Missing DOI and make reference format uniform

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Update and make references uniform for manuscript
+
 v0.3.1 (2023-04-12)
 ------------------------------------------------------------
 

--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -55,51 +55,31 @@
 }
 
 @article{Jumper2021,
-  title     = "Highly accurate protein structure prediction with {AlphaFold}",
-  author    = "Jumper, John and Evans, Richard and Pritzel, Alexander and
-               Green, Tim and Figurnov, Michael and Ronneberger, Olaf and
-               Tunyasuvunakool, Kathryn and Bates, Russ and {\v Z}{\'\i}dek,
-               Augustin and Potapenko, Anna and Bridgland, Alex and Meyer,
-               Clemens and Kohl, Simon A A and Ballard, Andrew J and Cowie,
-               Andrew and Romera-Paredes, Bernardino and Nikolov, Stanislav and
-               Jain, Rishub and Adler, Jonas and Back, Trevor and Petersen,
-               Stig and Reiman, David and Clancy, Ellen and Zielinski, Michal
-               and Steinegger, Martin and Pacholska, Michalina and Berghammer,
-               Tamas and Bodenstein, Sebastian and Silver, David and Vinyals,
-               Oriol and Senior, Andrew W and Kavukcuoglu, Koray and Kohli,
-               Pushmeet and Hassabis, Demis",
-  journal   = "Nature",
-  publisher = "Springer Science and Business Media LLC",
-  volume    =  596,
-  number    =  7873,
-  pages     = "583--589",
-  month     =  aug,
-  year      =  2021,
-  copyright = "https://creativecommons.org/licenses/by/4.0",
-  language  = "en"
+  doi = {10.1038/s41586-021-03819-2},
+  url = {https://doi.org/10.1038/s41586-021-03819-2},
+  year = {2021},
+  month = jul,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {596},
+  number = {7873},
+  pages = {583--589},
+  author = {John Jumper and Richard Evans and Alexander Pritzel and Tim Green and Michael Figurnov and Olaf Ronneberger and Kathryn Tunyasuvunakool and Russ Bates and Augustin {\v{Z}}{\'{\i}}dek and Anna Potapenko and Alex Bridgland and Clemens Meyer and Simon A. A. Kohl and Andrew J. Ballard and Andrew Cowie and Bernardino Romera-Paredes and Stanislav Nikolov and Rishub Jain and Jonas Adler and Trevor Back and Stig Petersen and David Reiman and Ellen Clancy and Michal Zielinski and Martin Steinegger and Michalina Pacholska and Tamas Berghammer and Sebastian Bodenstein and David Silver and Oriol Vinyals and Andrew W. Senior and Koray Kavukcuoglu and Pushmeet Kohli and Demis Hassabis},
+  title = {Highly accurate protein structure prediction with {AlphaFold}},
+  journal = {Nature}
 }
 
 @article{Baek2021,
-  title     = "Accurate prediction of protein structures and interactions using a three-track neural network",
-  author    = "Baek, Minkyung and DiMaio, Frank and Anishchenko, Ivan and
-               Dauparas, Justas and Ovchinnikov, Sergey and Lee, Gyu Rie and
-               Wang, Jue and Cong, Qian and Kinch, Lisa N and Schaeffer, R
-               Dustin and Mill{\'a}n, Claudia and Park, Hahnbeom and Adams,
-               Carson and Glassman, Caleb R and DeGiovanni, Andy and Pereira,
-               Jose H and Rodrigues, Andria V and van Dijk, Alberdina A and
-               Ebrecht, Ana C and Opperman, Diederik J and Sagmeister, Theo and
-               Buhlheller, Christoph and Pavkov-Keller, Tea and Rathinaswamy,
-               Manoj K and Dalwadi, Udit and Yip, Calvin K and Burke, John E
-               and Garcia, K Christopher and Grishin, Nick V and Adams, Paul D
-               and Read, Randy J and Baker, David",
-  journal   = "Science",
-  publisher = "American Association for the Advancement of Science (AAAS)",
-  volume    =  373,
-  number    =  6557,
-  pages     = "871--876",
-  month     =  aug,
-  year      =  2021,
-  language  = "en"
+  doi = {10.1126/science.abj8754},
+  url = {https://doi.org/10.1126/science.abj8754},
+  year = {2021},
+  month = aug,
+  publisher = {American Association for the Advancement of Science ({AAAS})},
+  volume = {373},
+  number = {6557},
+  pages = {871--876},
+  author = {Minkyung Baek and Frank DiMaio and Ivan Anishchenko and Justas Dauparas and Sergey Ovchinnikov and Gyu Rie Lee and Jue Wang and Qian Cong and Lisa N. Kinch and R. Dustin Schaeffer and Claudia Mill{\'{a}}n and Hahnbeom Park and Carson Adams and Caleb R. Glassman and Andy DeGiovanni and Jose H. Pereira and Andria V. Rodrigues and Alberdina A. van Dijk and Ana C. Ebrecht and Diederik J. Opperman and Theo Sagmeister and Christoph Buhlheller and Tea Pavkov-Keller and Manoj K. Rathinaswamy and Udit Dalwadi and Calvin K. Yip and John E. Burke and K. Christopher Garcia and Nick V. Grishin and Paul D. Adams and Randy J. Read and David Baker},
+  title = {Accurate prediction of protein structures and interactions using a three-track neural network},
+  journal = {Science}
 }
 
 @article{Mittag2007,
@@ -211,30 +191,31 @@
   journal = {Nucleic Acids Research}
 }
 
-@ARTICLE{Salvi2016,
-  title    = "Multi-timescale dynamics in intrinsically disordered proteins from {NMR} relaxation and molecular simulation",
-  author   = "Salvi, Nicola and Abyzov, Anton and Blackledge, Martin",
-  journal  = "J. Phys. Chem. Lett.",
-  volume   =  7,
-  number   =  13,
-  pages    = "2483--2489",
-  month    =  jul,
-  year     =  2016,
-  language = "en"
+@article{Salvi2016,
+  doi = {10.1021/acs.jpclett.6b00885},
+  url = {https://doi.org/10.1021/acs.jpclett.6b00885},
+  year = {2016},
+  month = jun,
+  publisher = {American Chemical Society ({ACS})},
+  volume = {7},
+  number = {13},
+  pages = {2483--2489},
+  author = {Nicola Salvi and Anton Abyzov and Martin Blackledge},
+  title = {Multi-Timescale Dynamics in Intrinsically Disordered Proteins from {NMR} Relaxation and Molecular Simulation},
+  journal = {The Journal of Physical Chemistry Letters}
 }
 
-@ARTICLE{Robustelli2018,
-  title     = "Developing a molecular dynamics force field for both folded and disordered protein states",
-  author    = "Robustelli, Paul and Piana, Stefano and Shaw, David E",
-  journal   = "Proc. Natl. Acad. Sci. U. S. A.",
-  publisher = "Proceedings of the National Academy of Sciences",
-  volume    =  115,
-  number    =  21,
-  pages     = "E4758--E4766",
-  month     =  may,
-  year      =  2018,
-  copyright = "https://creativecommons.org/licenses/by-nc-nd/4.0/",
-  language  = "en"
+@article{Robustelli2018,
+  doi = {10.1073/pnas.1800690115},
+  url = {https://doi.org/10.1073/pnas.1800690115},
+  year = {2018},
+  month = may,
+  publisher = {Proceedings of the National Academy of Sciences},
+  volume = {115},
+  number = {21},
+  author = {Paul Robustelli and Stefano Piana and David E. Shaw},
+  title = {Developing a molecular dynamics force field for both folded and disordered protein states},
+  journal = {Proceedings of the National Academy of Sciences}
 }
 
 @article{Krzeminski2012,
@@ -265,17 +246,15 @@
   journal = {Journal of the American Chemical Society}
 }
 
-@article{Zhang2022,
-  title         = "Learning to evolve structural ensembles of unfolded and disordered proteins using experimental solution data",
-  author        = "Zhang, Oufan and Haghighatlari, Mojtaba and Li, Jie and
-                   Teixeira, Joao Miguel Correia and Namini, Ashley and Liu,
-                   Zi-Hao and Forman-Kay, Julie D and Head-Gordon, Teresa",
-  month         =  jun,
-  year          =  2022,
-  copyright     = "http://arxiv.org/licenses/nonexclusive-distrib/1.0/",
-  archivePrefix = "arXiv",
-  primaryClass  = "physics.bio-ph",
-  eprint        = "2206.12667"
+@misc{Zhang2022,
+  doi = {10.48550/ARXIV.2206.12667},
+  url = {https://arxiv.org/abs/2206.12667},
+  author = {Zhang,  Oufan and Haghighatlari,  Mojtaba and Li,  Jie and Teixeira,  Joao Miguel Correia and Namini,  Ashley and Liu,  Zi-Hao and Forman-Kay,  Julie D and Head-Gordon,  Teresa},
+  keywords = {Biological Physics (physics.bio-ph),  FOS: Physical sciences,  FOS: Physical sciences},
+  title = {Learning to Evolve Structural Ensembles of Unfolded and Disordered Proteins Using Experimental Solution Data},
+  publisher = {arXiv},
+  year = {2022},
+  copyright = {arXiv.org perpetual,  non-exclusive license}
 }
 
 @article{Lincoff2020,
@@ -316,15 +295,17 @@
 }
 
 @article{Perez2001,
-  title    = "Self-consistent Karplus parametrization of {3J} couplings depending on the polypeptide side-chain torsion chi1",
-  author   = "P{\'e}rez, C and L{\"o}hr, F and R{\"u}terjans, H and Schmidt, J M",
-  journal  = "J. Am. Chem. Soc.",
-  volume   =  123,
-  number   =  29,
-  pages    = "7081--7093",
-  month    =  jul,
-  year     =  2001,
-  language = "en"
+  doi = {10.1021/ja003724j},
+  url = {https://doi.org/10.1021/ja003724j},
+  year = {2001},
+  month = jun,
+  publisher = {American Chemical Society ({ACS})},
+  volume = {123},
+  number = {29},
+  pages = {7081--7093},
+  author = {Carlos P{\'{e}}rez and Frank L\"{o}hr and Heinz R\"{u}terjans and J\"{u}rgen M. Schmidt},
+  title = {Self-Consistent Karplus Parametrization of 3J Couplings Depending on the Polypeptide Side-Chain Torsion chi1},
+  journal = {Journal of the American Chemical Society}
 }
 
 @article{Franke2017,
@@ -370,17 +351,17 @@
 }
 
 @article{Naudi-Fabra2021,
-  title     = "Quantitative description of intrinsically disordered proteins using single-molecule {FRET}, {NMR}, and {SAXS}",
-  author    = "Naudi-Fabra, Samuel and Tengo, Maud and Jensen, Malene Ringkj{\o}bing and Blackledge, Martin and Milles, Sigrid",
-  journal   = "J. Am. Chem. Soc.",
-  publisher = "American Chemical Society (ACS)",
-  volume    =  143,
-  number    =  48,
-  pages     = "20109--20121",
-  month     =  dec,
-  year      =  2021,
-  copyright = "https://creativecommons.org/licenses/by/4.0/",
-  language  = "en"
+  doi = {10.1021/jacs.1c06264},
+  url = {https://doi.org/10.1021/jacs.1c06264},
+  year = {2021},
+  month = nov,
+  publisher = {American Chemical Society ({ACS})},
+  volume = {143},
+  number = {48},
+  pages = {20109--20121},
+  author = {Samuel Naudi-Fabra and Maud Tengo and Malene Ringkj{\o}bing Jensen and Martin Blackledge and Sigrid Milles},
+  title = {Quantitative Description of Intrinsically Disordered Proteins Using Single-Molecule {FRET},  {NMR},  and {SAXS}},
+  journal = {Journal of the American Chemical Society}
 }
 
 @misc{pyskeleton,


### PR DESCRIPTION
[Re: JOSS Reviews](https://github.com/openjournals/joss-reviews/issues/4861)

Made references in the same format and addresses any missing DOI issues.